### PR TITLE
Launch Nestest.nes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	mkdir -p wasm
 	rm -rf target/wasm32-unknown-emscripten/release/deps/*.wasm
 	rm -rf target/wasm32-unknown-emscripten/release/nes_emulator.js
-	cargo rustc --release --bin nes_emulator \
+	cargo rustc --release \
 	--target=wasm32-unknown-emscripten -- \
     -C opt-level=3 \
 	-C link-args="-O3 -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS=['_run'] -s EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap']" \

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ const startArrayBuf = (arrayBuf) => {
 }
 
 // called from html
-export const start = async (rom = './roms/sample1.nes') => {
+export const start = async (rom = './roms/nestest.nes') => {
   const res = await fetch(rom);
   const arrayBuf = await res.arrayBuffer();
   startArrayBuf(arrayBuf);

--- a/src/nes/bus/cpu_bus.rs
+++ b/src/nes/bus/cpu_bus.rs
@@ -62,6 +62,7 @@ impl<'a> CpuBus for Bus<'a> {
       0x0000..=0x1FFF => self.work_ram.write(addr & 0x07FF, data),
       0x2000..=0x3FFF => self.ppu.write(addr - 0x2000, data),
       0x4014 => self.dma.write(data),
+      0x4000..=0x401F => (), // TODO: apu
       0x6000..=0x7FFF => {
         println!("Not implemented. This area is battery backup ram area 0x{:x}", addr );
       }

--- a/src/nes/bus/cpu_bus.rs
+++ b/src/nes/bus/cpu_bus.rs
@@ -44,6 +44,9 @@ impl<'a> CpuBus for Bus<'a> {
     match addr {
       0x0000..=0x1FFF => self.work_ram.read(addr & 0x07FF),
       0x2000..=0x3FFF => self.ppu.read(addr - 0x2000),
+      0x4016 => 0, // TODO: keypad
+      0x4017 => 0, // TODO: 2player
+      0x4000...0x401F => 0, // TODO: apu
       0x6000..=0x7FFF => {
         println!("Not implemented. This area is battery backup ram area 0x{:x}", addr );
         0

--- a/src/nes/cpu/fetch.rs
+++ b/src/nes/cpu/fetch.rs
@@ -62,8 +62,8 @@ fn fetch_absolute_y<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) ->
 }
 
 fn fetch_indirect_x<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {
-  let addr = (fetch(register, bus) + register.get_X()) as Addr;
-  (bus.read(addr) as Addr) + ((bus.read(addr+1) as Addr) << 8)
+  let addr = ((fetch(register, bus) + register.get_X()) & 0xFF) as Addr;
+  (bus.read(addr) as Addr) + ((bus.read((addr + 1) as Addr & 0xFF) as Addr) << 8)
 }
 
 fn fetch_indirect_y<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {

--- a/src/nes/cpu/fetch.rs
+++ b/src/nes/cpu/fetch.rs
@@ -68,9 +68,8 @@ fn fetch_indirect_x<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) ->
 
 fn fetch_indirect_y<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {
   let addr = fetch(register, bus) as Addr;
-  let low = bus.read(addr) as Word;
-  let top = bus.read(addr + 1) as Word;
-  ((top << 8) | low) + (register.get_Y() as Word)
+  let base_addr = (bus.read(addr) as usize) + ((bus.read((addr + 1) & 0x00FF) as usize) * 0x100);
+  (base_addr + (register.get_Y() as usize)) as Addr
 }
 
 #[cfg(test)]

--- a/src/nes/cpu/fetch.rs
+++ b/src/nes/cpu/fetch.rs
@@ -23,6 +23,7 @@ pub fn fetch_operand<T: CpuRegister, U: CpuBus>(code: &Opecode, register: &mut T
     Addressing::Absolute => fetch_absolute(register, bus),
     Addressing::AbsoluteX => fetch_absolute_x(register, bus),
     Addressing::AbsoluteY => fetch_absolute_y(register, bus),
+    Addressing::AbsoluteIndirect => fetch_absolute_indirect(register, bus),
     Addressing::IndirectX => fetch_indirect_x(register, bus),
     Addressing::IndirectY => fetch_indirect_y(register, bus),
     _ => panic!("Invalid code"),
@@ -59,6 +60,12 @@ fn fetch_absolute_x<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) ->
 
 fn fetch_absolute_y<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {
   fetch_absolute(register, bus) + (register.get_Y() as Word)
+}
+
+fn fetch_absolute_indirect<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {
+  let addr = fetch_absolute(register, bus);
+  let upper = bus.read((addr & 0xFF00) | ((((addr & 0xFF) + 1) & 0xFF)) as Addr) as Addr;
+  (bus.read(addr) as Addr) + (upper << 8) as Addr
 }
 
 fn fetch_indirect_x<T: CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) -> Addr {

--- a/src/nes/cpu/instructions.rs
+++ b/src/nes/cpu/instructions.rs
@@ -436,7 +436,7 @@ pub fn rts<T:CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) {
 pub fn rti<T:CpuRegister, U: CpuBus>(register: &mut T, bus: &mut U) {
   pop_status(register, bus);
   pop_pc(register, bus);
-  register.increment_PC();
+  register.set_status_reserved(true);
 }
 
 pub fn bcc<T:CpuRegister>(operand: Addr, register: &mut T) {

--- a/src/nes/cpu/instructions.rs
+++ b/src/nes/cpu/instructions.rs
@@ -104,9 +104,7 @@ pub fn txa<T: CpuRegister>(register: &mut T) {
 pub fn txs<T: CpuRegister>(register: &mut T) {
   let v = register.get_X();
   register
-    .set_S(v)
-    .update_status_negative_by(v)
-    .update_status_zero_by(v);
+    .set_S(v);
 }
 
 pub fn tya<T: CpuRegister>(register: &mut T) {

--- a/src/nes/cpu/instructions.rs
+++ b/src/nes/cpu/instructions.rs
@@ -159,21 +159,23 @@ pub fn and<T: CpuRegister, U: CpuBus>(operand: Word, register: &mut T, bus: &mut
 }
 
 pub fn asl_acc<T: CpuRegister>(register: &mut T) {
-  let a = register.get_A() << 1;
+  let a = register.get_A();
+  let shifted = (a << 1) as Data;
   register
     .set_status_carry((a & 0x80) == 0x80)
-    .update_status_negative_by(a)
-    .update_status_zero_by(a)
-    .set_A(a);
+    .update_status_negative_by(shifted)
+    .update_status_zero_by(shifted)
+    .set_A(shifted);
 }
 
 pub fn asl<T: CpuRegister, U: CpuBus>(operand: Word, register: &mut T, bus: &mut U) {
-  let fetched = bus.read(operand) << 1;
+  let fetched = bus.read(operand);
+  let shifted = fetched << 1;
   register
     .set_status_carry((fetched & 0x80) == 0x80)
-    .update_status_negative_by(fetched)
-    .update_status_zero_by(fetched);
-  bus.write(operand, fetched);
+    .update_status_negative_by(shifted)
+    .update_status_zero_by(shifted);
+  bus.write(operand, shifted);
 }
 
 pub fn bit<T: CpuRegister, U: CpuBus>(operand: Word, register: &mut T, bus: &mut U) {

--- a/src/nes/cpu/mod.rs
+++ b/src/nes/cpu/mod.rs
@@ -104,7 +104,14 @@ pub fn run<T: CpuRegister, U: CpuBus>(register: &mut T, cpu_bus: &mut U, _nmi: &
 
     Instruction::BRK => brk(register, cpu_bus),
     Instruction::NOP => (),
-    _ => panic!("Invalid code"),
+    Instruction::LAX => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::SAX => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::DCP => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::ISB => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::SLO => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::RLA => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::SRE => println!("{}", "TODO:Undocumented instruction"),
+    Instruction::RRA => println!("{}", "TODO:Undocumented instruction"),
   }
   code.cycle
 }

--- a/src/nes/cpu/mod.rs
+++ b/src/nes/cpu/mod.rs
@@ -112,6 +112,7 @@ pub fn run<T: CpuRegister, U: CpuBus>(register: &mut T, cpu_bus: &mut U, _nmi: &
     Instruction::RLA => println!("{}", "TODO:Undocumented instruction"),
     Instruction::SRE => println!("{}", "TODO:Undocumented instruction"),
     Instruction::RRA => println!("{}", "TODO:Undocumented instruction"),
+    _ => panic!("Invalid code{:?}", code),
   }
   code.cycle
 }

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -355,6 +355,9 @@ lazy_static! {
     m.insert(0x7B, Opecode { name: Instruction::RRA, mode: Addressing::AbsoluteY, cycle:7 });
     m.insert(0x63, Opecode { name: Instruction::RRA, mode: Addressing::IndirectX, cycle: 8 });
     m.insert(0x73, Opecode { name: Instruction::RRA, mode: Addressing::IndirectY, cycle: 8});
+
+    // nestest
+    m.insert(0xEB, Opecode { name: Instruction::SBC, mode: Addressing::Immediate, cycle: 2 });
     m
   };
 }

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -148,8 +148,8 @@ lazy_static! {
     m.insert(0x2D, Opecode{ name: Instruction::AND, mode: Addressing::Absolute, cycle: 4});
     m.insert(0x3D, Opecode{ name: Instruction::AND, mode: Addressing::AbsoluteX, cycle: 4});
     m.insert(0x39, Opecode{ name: Instruction::AND, mode: Addressing::AbsoluteY, cycle: 4});
-    m.insert(0x21, Opecode{ name: Instruction::AND, mode: Addressing::IndirectX, cycle: 4});
-    m.insert(0x31, Opecode{ name: Instruction::AND, mode: Addressing::IndirectY, cycle: 4});
+    m.insert(0x21, Opecode{ name: Instruction::AND, mode: Addressing::IndirectX, cycle: 6});
+    m.insert(0x31, Opecode{ name: Instruction::AND, mode: Addressing::IndirectY, cycle: 5});
     m.insert(0x0A, Opecode{ name: Instruction::ASL, mode: Addressing::Accumulator, cycle: 2});
     m.insert(0x06, Opecode{ name: Instruction::ASL, mode: Addressing::Zeropage, cycle: 5});
     m.insert(0x16, Opecode{ name: Instruction::ASL, mode: Addressing::ZeropageX, cycle: 6});

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -73,6 +73,15 @@ pub enum Instruction {
   // others
   BRK,
   NOP,
+  // undocumented
+  LAX,
+  SAX,
+  DCP,
+  ISB,
+  SLO,
+  RLA,
+  SRE,
+  RRA,
 }
 
 #[derive(Debug, PartialEq)]
@@ -253,6 +262,59 @@ lazy_static! {
     // others
     m.insert(0x00, Opecode{ name: Instruction::BRK, mode: Addressing::Implied, cycle: 7});
     m.insert(0xEA, Opecode{ name: Instruction::NOP, mode: Addressing::Implied, cycle: 2});
+    // undocumented
+    m.insert(0xA7, Opecode { name: Instruction::LAX, mode: Addressing::Zeropage, cycle: 2 });
+    m.insert(0xB7, Opecode { name: Instruction::LAX, mode: Addressing::ZeropageY, cycle: 3 });
+    m.insert(0xAF, Opecode { name: Instruction::LAX, mode: Addressing::Absolute, cycle: 4 });
+    m.insert(0xBF, Opecode { name: Instruction::LAX, mode: Addressing::AbsoluteY, cycle: 4 });
+    m.insert(0xA3, Opecode { name: Instruction::LAX, mode: Addressing::IndirectX, cycle: 4 });
+    m.insert(0xB3, Opecode { name: Instruction::LAX, mode: Addressing::IndirectY, cycle:5 });
+    m.insert(0x87, Opecode { name: Instruction::SAX, mode: Addressing::Zeropage, cycle: 3});
+    m.insert(0x97, Opecode { name: Instruction::SAX, mode: Addressing::ZeropageY, cycle: 4});
+    m.insert(0x8F, Opecode { name: Instruction::SAX, mode: Addressing::Absolute, cycle: 4 });
+    m.insert(0x83, Opecode { name: Instruction::SAX, mode: Addressing::IndirectX, cycle:6 });
+    m.insert(0xC7, Opecode { name: Instruction::DCP, mode: Addressing::Zeropage, cycle: 5 });
+    m.insert(0xD7, Opecode { name: Instruction::DCP, mode: Addressing::ZeropageX, cycle: 6 });
+    m.insert(0xCF, Opecode { name: Instruction::DCP, mode: Addressing::Absolute, cycle: 6 });
+    m.insert(0xDF, Opecode { name: Instruction::DCP, mode: Addressing::AbsoluteX, cycle: 7 });
+    m.insert(0xDB, Opecode { name: Instruction::DCP, mode: Addressing::AbsoluteY, cycle:2 });
+    m.insert(0xC3, Opecode { name: Instruction::DCP, mode: Addressing::IndirectX, cycle: 8 });
+    m.insert(0xD3, Opecode { name: Instruction::DCP, mode: Addressing::IndirectY, cycle: 8 });
+    m.insert(0xE7, Opecode { name: Instruction::ISB, mode: Addressing::Zeropage, cycle: 5 });
+    m.insert(0xF7, Opecode { name: Instruction::ISB, mode: Addressing::ZeropageX, cycle:6 });
+    m.insert(0xEF, Opecode { name: Instruction::ISB, mode: Addressing::Absolute, cycle: 6 });
+    m.insert(0xFF, Opecode { name: Instruction::ISB, mode: Addressing::AbsoluteX, cycle: 7 });
+    m.insert(0xFB, Opecode { name: Instruction::ISB, mode: Addressing::AbsoluteY, cycle: 2 });
+    m.insert(0xE3, Opecode { name: Instruction::ISB, mode: Addressing::IndirectX, cycle: 8});
+    m.insert(0xF3, Opecode { name: Instruction::ISB, mode: Addressing::IndirectY, cycle: 8});
+    m.insert(0x07, Opecode { name: Instruction::SLO, mode: Addressing::Zeropage, cycle: 5 });
+    m.insert(0x17, Opecode { name: Instruction::SLO, mode: Addressing::ZeropageX, cycle: 6 });
+    m.insert(0x0F, Opecode { name: Instruction::SLO, mode: Addressing::Absolute, cycle: 6 });
+    m.insert(0x1F, Opecode { name: Instruction::SLO, mode: Addressing::AbsoluteX, cycle:7 });
+    m.insert(0x1B, Opecode { name: Instruction::SLO, mode: Addressing::AbsoluteY, cycle: 7 });
+    m.insert(0x03, Opecode { name: Instruction::SLO, mode: Addressing::IndirectX, cycle: 8});
+    m.insert(0x13, Opecode { name: Instruction::SLO, mode: Addressing::IndirectY, cycle: 8 });
+    m.insert(0x27, Opecode { name: Instruction::RLA, mode: Addressing::Zeropage, cycle: 5 });
+    m.insert(0x37, Opecode { name: Instruction::RLA, mode: Addressing::ZeropageX, cycle: 6 });
+    m.insert(0x2F, Opecode { name: Instruction::RLA, mode: Addressing::Absolute, cycle:6});
+    m.insert(0x3F, Opecode { name: Instruction::RLA, mode: Addressing::AbsoluteX, cycle:7});
+    m.insert(0x3B, Opecode { name: Instruction::RLA, mode: Addressing::AbsoluteY, cycle: 7 });
+    m.insert(0x23, Opecode { name: Instruction::RLA, mode: Addressing::IndirectX, cycle: 8 });
+    m.insert(0x33, Opecode { name: Instruction::RLA, mode: Addressing::IndirectY, cycle: 8 }, );
+    m.insert(0x47, Opecode { name: Instruction::SRE, mode: Addressing::Zeropage, cycle: 5});
+    m.insert(0x57, Opecode { name: Instruction::SRE, mode: Addressing::ZeropageX, cycle: 6 });
+    m.insert(0x4F, Opecode { name: Instruction::SRE, mode: Addressing::Absolute, cycle: 6 });
+    m.insert(0x5F, Opecode { name: Instruction::SRE, mode: Addressing::AbsoluteX, cycle:7 });
+    m.insert(0x5B, Opecode { name: Instruction::SRE, mode: Addressing::AbsoluteY, cycle:7});
+    m.insert(0x43, Opecode { name: Instruction::SRE, mode: Addressing::IndirectX, cycle: 8 });
+    m.insert(0x53, Opecode { name: Instruction::SRE, mode: Addressing::IndirectY, cycle: 8 }, );
+    m.insert(0x67, Opecode { name: Instruction::RRA, mode: Addressing::Zeropage, cycle: 5});
+    m.insert(0x77, Opecode { name: Instruction::RRA, mode: Addressing::ZeropageX, cycle: 6});
+    m.insert(0x6F, Opecode { name: Instruction::RRA, mode: Addressing::Absolute, cycle: 6 });
+    m.insert(0x7F, Opecode { name: Instruction::RRA, mode: Addressing::AbsoluteX, cycle: 7 });
+    m.insert(0x7B, Opecode { name: Instruction::RRA, mode: Addressing::AbsoluteY, cycle:7 });
+    m.insert(0x63, Opecode { name: Instruction::RRA, mode: Addressing::IndirectX, cycle: 8 });
+    m.insert(0x73, Opecode { name: Instruction::RRA, mode: Addressing::IndirectY, cycle: 8});
     m
   };
 }

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -87,7 +87,7 @@ pub enum Addressing {
   Absolute,
   AbsoluteX,
   AbsoluteY,
-  Indirect,
+  AbsoluteIndirect,
   IndirectX,
   IndirectY,
 }
@@ -229,7 +229,7 @@ lazy_static! {
     m.insert(0x28, Opecode{ name: Instruction::PLP, mode: Addressing::Implied, cycle: 4});
     // jump
     m.insert(0x4C, Opecode{ name: Instruction::JMP, mode: Addressing::Absolute, cycle: 3});
-    m.insert(0x6C, Opecode{ name: Instruction::JMP, mode: Addressing::Indirect, cycle: 5});
+    m.insert(0x6C, Opecode{ name: Instruction::JMP, mode: Addressing::AbsoluteIndirect, cycle: 5});
     m.insert(0x20, Opecode{ name: Instruction::JSR, mode: Addressing::Absolute, cycle: 6});
     m.insert(0x60, Opecode{ name: Instruction::RTS, mode: Addressing::Implied, cycle: 6});
     m.insert(0x40, Opecode{ name: Instruction::RTI, mode: Addressing::Implied, cycle: 6});

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -303,11 +303,11 @@ lazy_static! {
     m.insert(0xFC, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
 
     // undocumented
-    m.insert(0xA7, Opecode { name: Instruction::LAX, mode: Addressing::Zeropage, cycle: 2 });
+    m.insert(0xA7, Opecode { name: Instruction::LAX, mode: Addressing::Zeropage, cycle: 3 });
     m.insert(0xB7, Opecode { name: Instruction::LAX, mode: Addressing::ZeropageY, cycle: 3 });
     m.insert(0xAF, Opecode { name: Instruction::LAX, mode: Addressing::Absolute, cycle: 4 });
     m.insert(0xBF, Opecode { name: Instruction::LAX, mode: Addressing::AbsoluteY, cycle: 4 });
-    m.insert(0xA3, Opecode { name: Instruction::LAX, mode: Addressing::IndirectX, cycle: 4 });
+    m.insert(0xA3, Opecode { name: Instruction::LAX, mode: Addressing::IndirectX, cycle: 6 });
     m.insert(0xB3, Opecode { name: Instruction::LAX, mode: Addressing::IndirectY, cycle:5 });
     m.insert(0x87, Opecode { name: Instruction::SAX, mode: Addressing::Zeropage, cycle: 3});
     m.insert(0x97, Opecode { name: Instruction::SAX, mode: Addressing::ZeropageY, cycle: 4});

--- a/src/nes/cpu/opecodes.rs
+++ b/src/nes/cpu/opecodes.rs
@@ -262,6 +262,46 @@ lazy_static! {
     // others
     m.insert(0x00, Opecode{ name: Instruction::BRK, mode: Addressing::Implied, cycle: 7});
     m.insert(0xEA, Opecode{ name: Instruction::NOP, mode: Addressing::Implied, cycle: 2});
+    m.insert(0x1A, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x3A, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x5A, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x7A, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xDA, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xFA, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x02, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x12, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x22, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x32, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x42, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x52, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x62, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x72, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x92, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xB2, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xD2, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xF2, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x80, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x82, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0x89, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xC2, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 2 });
+    m.insert(0xE2, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 3 });
+    m.insert(0x04, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 3 });
+    m.insert(0x44, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 3 });
+    m.insert(0x64, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 3 });
+    m.insert(0x14, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x34, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x54, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x74, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0xD4, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0xF4, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x0C, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x1C, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x3C, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x5C, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0x7C, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0xDC, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+    m.insert(0xFC, Opecode { name: Instruction::NOP, mode: Addressing::Implied, cycle: 4 });
+
     // undocumented
     m.insert(0xA7, Opecode { name: Instruction::LAX, mode: Addressing::Zeropage, cycle: 2 });
     m.insert(0xB7, Opecode { name: Instruction::LAX, mode: Addressing::ZeropageY, cycle: 3 });

--- a/src/nes/ppu/register/mod.rs
+++ b/src/nes/ppu/register/mod.rs
@@ -143,7 +143,7 @@ impl PpuRegister for Register {
   }
 
   fn clear_sprite_hit(&mut self) {
-    self.ppu_status &= 0x40
+    self.ppu_status &= 0xbF
   }
 
   fn set_vblank(&mut self) {


### PR DESCRIPTION
# overview
- execute `Nestest.nes` by `cpu` and `ppu` on `emscripten` and `wasm`.
  - `no sound`
  - `no keypad`

<img width="568" alt="スクリーンショット 2020-03-10 20 08 41" src="https://user-images.githubusercontent.com/22634362/76309884-10763e80-6311-11ea-9a1a-a17e61012a8d.png">

- Add cpu undocumented opecode
- Fix cpu opecode
- Fix `fetch_indirect_y()` logic 6c016f9
- Follow non covered bus addressing
- Fix ppu register method to render nestest

# bug fix
- vblnak flag cleared by `clear_sprite_hit()` 

# nestest.nes
here: https://wiki.nesdev.com/w/index.php/Emulator_tests

